### PR TITLE
big website redesign

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -33,9 +33,11 @@ jobs:
 
       - name: Install MkDocs
         run: |
-          pip install mkdocs
-          pip install mkdocs-literate-nav
-          pip install mkdocs-enumerate-headings-plugin
+          pip install \
+            mkdocs-material \
+            mkdocs-literate-nav \
+            mkdocs-enumerate-headings-plugin \
+            pymdown-extensions
 
       - name: Build with MkDocs
         run: mkdocs build

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,20 @@
-Ez a szakmai gyakorlat weboldala, egyelőre csak a [Project Terv](project-plan) van kész.
+# Túlélés a Szocializmusban
+
+A "Túlélés a Szocializmusban" című játék egy túlélés-orientált szimuláció,
+amely a szocialista korszak mindennapjainak nehézségeit és sajátos társadalmi
+dinamikáját dolgozza fel. A játék célja, hogy a játékos egy államilag szabályozott,
+korlátozott lehetőségeket kínáló rendszerben találja meg a túlélés útját -- akár
+törvényes, akár féllegális eszközökkel. A projekt célközönsége a komolyabb hangvételű
+szimulációs élményeket kereső játékosok, akik érdeklődnek a történelmi ihletésű,
+morális döntéseket is tartalmazó játékmenetek iránt.
+
+A játék cselekménye egy fiktív, ám a valódi szocialista rendszerek jegyeit idéző világban
+játszódik. A játékos feladata, hogy saját és családja mindennapi megélhetését biztosítsa
+egy gazdaságilag nyomott, bizonytalanságokkal teli korszakban, ahol a legkisebb döntés is
+súlyos következményekkel járhat.
+
+A játékmenet középpontjában a túlélés áll: a játékos folyamatosan mérlegeli, hogyan ossza
+be idejét és szűkös erőforrásait a munka, a család, valamint a saját testi-lelki állapotának
+megőrzése között.
+
+További információ a [Projekt Terv](project-plan) oldalon található.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,26 +2,49 @@ site_name: SzakGyak
 repo_url: https://github.com/JanosSandor2002/SzakGyak
 
 nav:
-  - 'Project Terv': project-plan/*
+  - 'Project Terv': project-plan/
   - 'Dokumentáció':
     - documentation/vision.md
-    - documentation/*
-  - 'Munkanapló': work-log/*
+    - documentation/srs.md
+    - documentation/analysismodel.md
+    - documentation/systemarch.md
+  - 'Munkanapló': 'https://docs.google.com/spreadsheets/d/1jSlDk9d3kgoSkNY78S58bChsSggCFRqs5fNXPh3aXEc'
 
 plugins:
   - search
   - literate-nav
   - enumerate-headings:
-      toc_depth: 6
-      exclude:
-        - work-log/*
-        - documentation/index.md
       restart_increment_after:
-        - documentation/vision.md
+      - documentation/vision.md
 
 theme: 
-  name: mkdocs
-  navigation_depth: 999
+  name: material
+  features:
+    - navigation.tabs
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: red
+      accent: red
+      toggle:
+        icon: material/weather-night
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: red
+      accent: red
+      toggle:
+        icon: material/weather-sunny
 
 markdown_extensions:
   - smarty
+  - toc:
+      toc_depth: 999
+      permalink: true
+  - admonition
+  - pymdownx.details
+  - pymdownx.extra
+  - pymdownx.superfences
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - pymdownx.escapeall:
+      hardbreak: true


### PR DESCRIPTION
changes:

- website now use [material theme](https://squidfunk.github.io/mkdocs-material/), which is easier to customize and more mobile friendly
- github link now correctly points to the repo instead of editing the page
- dark mode support
- work log moved to external site
- add content to home page